### PR TITLE
Fixed bug of not properly resetting parameters during multishot pruning

### DIFF
--- a/Experiments/multishot.py
+++ b/Experiments/multishot.py
@@ -64,7 +64,7 @@ def run(args):
 
                 # Reset Model's Weights
                 original_dict = torch.load("{}/model.pt".format(args.result_dir), map_location=device)
-                original_weights = dict(filter(lambda v: (v[1].requires_grad == True), original_dict.items()))
+                original_weights = dict(filter(lambda v: (v[0].endswith(('.weight', '.bias'))), original_dict.items()))
                 model_dict = model.state_dict()
                 model_dict.update(original_weights)
                 model.load_state_dict(model_dict)


### PR DESCRIPTION
Loading a saved state_dict leaves the requires_grad flag default initialized (to false), hence the filter in line multishot.py:67 yielded an empty dict. The parameters were hence not updated and for consecutive rounds, trained parameters were used instead of parameters resetted to initialization.